### PR TITLE
WIP: Fix setups behind https proxy

### DIFF
--- a/spotmop.php
+++ b/spotmop.php
@@ -85,7 +85,7 @@ function getAuthorizationCode( $url ){
 			window.addEventListener('message', function(event){
 				
 				// only allow incoming data from our authentication proxy site
-				if( event.origin !== "http://jamesbarnsley.co.nz" )
+				if( !/^https?:\/\/jamesbarnsley\.co\.nz/.test(event.origin) )
 					return false;
 
 				// pass the message on to the Angular application

--- a/src/app/services/lastfm/service.js
+++ b/src/app/services/lastfm/service.js
@@ -61,7 +61,7 @@ angular.module('spotmop.services.lastfm', [])
 	};
 	
 	// specify the base URL for the API endpoints
-    var urlBase = 'http://ws.audioscrobbler.com/2.0';
+    var urlBase = '//ws.audioscrobbler.com/2.0';
 	var apiKey = SettingsService.getSetting("lastfm,key");
 	if( !apiKey ) apiKey = '4320a3ef51c9b3d69de552ac083c55e3';
 	

--- a/src/app/services/mopidy/service.js
+++ b/src/app/services/mopidy/service.js
@@ -84,7 +84,7 @@ angular.module('spotmop.services.mopidy', [
 			// Initialize mopidy
             try{
     			this.mopidy = new Mopidy({
-    				webSocketUrl: "ws://" + mopidyhost + ":" + mopidyport + "/mopidy/ws", // FOR DEVELOPING 
+				webSocketUrl: "//" + mopidyhost + ":" + mopidyport + "/mopidy/ws", // FOR DEVELOPING
     				callingConvention: 'by-position-or-by-name'
     			});
 		

--- a/src/app/services/pusher/service.js
+++ b/src/app/services/pusher/service.js
@@ -15,7 +15,7 @@ angular.module('spotmop.services.pusher', [
 	var mopidyport = SettingsService.getSetting("mopidy.port");
 	if( !mopidyport ) mopidyport = "6680";
 	
-	var urlBase = 'http://'+ mopidyhost +':'+ mopidyport +'/spotmop/';
+	var urlBase = '//'+ mopidyhost +':'+ mopidyport +'/spotmop/';
     
 	$rootScope.$on('spotmop:pusher:client_connected', function(event, data){
 	
@@ -36,7 +36,7 @@ angular.module('spotmop.services.pusher', [
 			if( !pusherport ) pusherport = "6681";
 			
             try{
-				var host = 'ws://'+pusherhost+':'+pusherport+'/pusher';
+				var host = '//'+pusherhost+':'+pusherport+'/pusher';
                 
                 var connectionid = Math.random().toString(36).substr(2, 9);
                 SettingsService.setSetting('pusher.connectionid', connectionid);

--- a/src/app/services/spotify/service.js
+++ b/src/app/services/spotify/service.js
@@ -18,7 +18,7 @@ angular.module('spotmop.services.spotify', [])
 		start: function(){
 	
 			// inject our authorization frame, on the placeholder action
-			var frame = $('<iframe id="authorization-frame" style="width: 1px; height: 1px; display: none;" src="http://jamesbarnsley.co.nz/spotmop.php?action=frame"></iframe>');
+			var frame = $('<iframe id="authorization-frame" style="width: 1px; height: 1px; display: none;" src="//jamesbarnsley.co.nz/spotmop.php?action=frame"></iframe>');
 			$(body).append(frame);
 			
 			// set container for spotify storage
@@ -41,7 +41,7 @@ angular.module('spotmop.services.spotify', [])
 			window.addEventListener('message', function(event){
 				
 				// only allow incoming data from our authorized authenticator proxy
-				if( event.origin !== "http://jamesbarnsley.co.nz" )
+				if( !/^https?:\/\/jamesbarnsley\.co\.nz/.test(event.origin) )
 					return false;
 				
 				// convert to json
@@ -94,7 +94,7 @@ angular.module('spotmop.services.spotify', [])
 		 **/
 		authorize: function(){
 			var frame = $(document).find('#authorization-frame');
-			frame.attr('src', 'http://jamesbarnsley.co.nz/spotmop.php?action=authorize&app='+location.protocol+'//'+window.location.host );
+			frame.attr('src', '//jamesbarnsley.co.nz/spotmop.php?action=authorize&app='+location.protocol+'//'+window.location.host );
 		},
 		
 		isAuthorized: function(){
@@ -116,7 +116,7 @@ angular.module('spotmop.services.spotify', [])
 			// sweet, client has authorized interface!
 			if( this.authenticationMethod == 'client' ){
 			
-				url = 'http://jamesbarnsley.co.nz/spotmop.php?action=refresh&refresh_token='+$localStorage.spotify.RefreshToken;
+				url = '//jamesbarnsley.co.nz/spotmop.php?action=refresh&refresh_token='+$localStorage.spotify.RefreshToken;
 			
 			// client hasn't authorized spotmop with spotify, so let's just use the backend
 			}else if( this.authenticationMethod == 'server' ){
@@ -125,7 +125,7 @@ angular.module('spotmop.services.spotify', [])
 				if( !mopidyhost ) mopidyhost = window.location.hostname;
 				var mopidyport = SettingsService.getSetting("mopidy.port");
 				if( !mopidyport ) mopidyport = "6680";
-				url = 'http://'+mopidyhost+':'+mopidyport+'/spotmop/auth';
+				url = '//'+mopidyhost+':'+mopidyport+'/spotmop/auth';
 			
 			// no authentication method, so cannot refresh token!
 			}else{

--- a/src/app/settings/service.js
+++ b/src/app/settings/service.js
@@ -211,7 +211,7 @@ angular.module('spotmop.services.settings', [])
 	var mopidyport = service.getSetting("mopidy.port");
 	if( !mopidyport ) mopidyport = "6680";
 	
-	var urlBase = 'http://'+ mopidyhost +':'+ mopidyport +'/spotmop/';
+	var urlBase = '//'+ mopidyhost +':'+ mopidyport +'/spotmop/';
 	
 	return service;	
 }]);


### PR DESCRIPTION
I stumbled upon the same problem as @qurben in #53 - I configured nginx + letsencrypt as a proxy in front of mopidy http server. I basically need the following entries in the config for this to work:

```
location /pusher {
        proxy_pass http://127.0.0.1:6681/;
        proxy_set_header Host $host;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
}
location / {
        proxy_pass http://127.0.0.1:6680/;
        proxy_set_header Host $host;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
}
```

After that, in the spotmop settings pane, point everything to the webserver on port 443 (notifications port + mopidy host + port).
